### PR TITLE
feat: add MPS (Apple Silicon) support for inference

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -11,8 +11,11 @@ import tempfile
 
 MAX_SEED = np.iinfo(np.int32).max
 
+device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+dtype = torch.bfloat16 if device != "cpu" else torch.float32
+
 pipeline = QwenImageLayeredPipeline.from_pretrained("Qwen/Qwen-Image-Layered")
-pipeline = pipeline.to("cuda", torch.bfloat16)
+pipeline = pipeline.to(device, dtype)
 pipeline.set_progress_bar_config(disable=None)
 
 def imagelist_to_pptx(img_files):
@@ -72,7 +75,7 @@ def infer(input_image,
     
     inputs = {
         "image": pil_image,
-        "generator": torch.Generator(device='cuda').manual_seed(seed),
+        "generator": torch.Generator(device=device).manual_seed(seed),
         "true_cfg_scale": true_guidance_scale,
         "prompt": prompt,
         "negative_prompt": neg_prompt,

--- a/src/tool/edit_rgba_image.py
+++ b/src/tool/edit_rgba_image.py
@@ -9,8 +9,8 @@ from transformers import AutoModelForImageSegmentation
 from diffusers import QwenImageEditPlusPipeline
 
 # --- Model Loading ---
-dtype = torch.bfloat16
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+dtype = torch.bfloat16 if device != "cpu" else torch.float32
 
 # Load the model pipeline
 pipe = QwenImageEditPlusPipeline.from_pretrained("Qwen/Qwen-Image-Edit-2509", torch_dtype=dtype).to(device)


### PR DESCRIPTION
Support MPS backend for inference

* Updated device selection logic to prefer CUDA if available, then MPS, then CPU in both `src/app.py` and `src/tool/edit_rgba_image.py`. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R14-R18) [[2]](diffhunk://#diff-8a347cdd2d9019c355af0e280c812921a08c6006a17376a791133d45814aa89cL12-R13)
* Set tensor data type to `torch.bfloat16` for CUDA/MPS devices and `torch.float32` for CPU. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R14-R18) [[2]](diffhunk://#diff-8a347cdd2d9019c355af0e280c812921a08c6006a17376a791133d45814aa89cL12-R13)
* Updated model pipeline initialization and `.to()` calls to use the new device and data type logic in both files. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R14-R18) [[2]](diffhunk://#diff-8a347cdd2d9019c355af0e280c812921a08c6006a17376a791133d45814aa89cL12-R13)
* Modified the generator in the `infer` function to use the selected device rather than hardcoding `'cuda'`.