### PR TITLE
Enable optional Gradio sharing via CLI flags (for Google Colab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The following scripts will start a Gradio-based web interface where you can deco
 python src/app.py
 ```
 
+For Google Colab, launch with `--share` to generate a public Gradio URL (e.g., `python src/app.py --share`).
+
 After decomposition, you may want to edit specific layers. The following scripts will launch a Gradio-based web interface where you can edit images with transparency using Qwen-Image-Edit.
 ```bash
 python src/tool/edit_rgba_image.py

--- a/src/app.py
+++ b/src/app.py
@@ -207,7 +207,17 @@ with gr.Blocks() as demo:
         outputs=gallery,
     )
 
-demo.launch(
-    server_name="0.0.0.0",
-    server_port=7869,
-)
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--share", action="store_true", help="Create a public Gradio link")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=7869)
+    args = parser.parse_args()
+
+    demo.launch(
+        share=args.share,
+        server_name=args.host,
+        server_port=args.port,
+    )


### PR DESCRIPTION
This PR makes the Gradio launch configurable via CLI flags to better support Google Colab usage.

`demo.launch()` is now executed under `__main__`, and `--share/--host/--port` are added so a public URL is generated only when `--share` is specified.

README was updated with a brief Colab usage note.

I’d appreciate a quick review; please let me know if you prefer different defaults or a different CLI interface.